### PR TITLE
Ruleset autoreload

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using System.Net;
 using System.Runtime;
 using System.Threading;
+using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Primitives;
@@ -44,6 +45,8 @@ namespace OpenRA
 
 		static WorldRenderer worldRenderer;
 		static string modLaunchWrapper;
+
+		public static RulesetWatcher RulesetWatcher;
 
 		internal static OrderManager OrderManager;
 		static Server.Server server;
@@ -198,6 +201,9 @@ namespace OpenRA
 
 			// Proactively collect memory during loading to reduce peak memory.
 			GC.Collect();
+
+			RulesetWatcher?.Dispose();
+			RulesetWatcher = new RulesetWatcher(OrderManager.World, ModData);
 
 			using (new PerfTimer("LoadComplete"))
 				OrderManager.World.LoadComplete(worldRenderer);

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -202,9 +202,6 @@ namespace OpenRA
 			// Proactively collect memory during loading to reduce peak memory.
 			GC.Collect();
 
-			RulesetWatcher?.Dispose();
-			RulesetWatcher = new RulesetWatcher(OrderManager.World, ModData);
-
 			using (new PerfTimer("LoadComplete"))
 				OrderManager.World.LoadComplete(worldRenderer);
 

--- a/OpenRA.Game/GameRules/Ruleset.cs
+++ b/OpenRA.Game/GameRules/Ruleset.cs
@@ -204,10 +204,13 @@ namespace OpenRA
 		{
 			if (ruleFiles == null || ruleFiles.Length == 0)
 			{
-				Console.WriteLine("No rule file specified, reloading all rule files.");
+				TextNotificationsManager.Debug("No rule file specified, reloading all rule files.");
 				ruleFiles = modData.Manifest.Rules;
 			}
+			else
+				TextNotificationsManager.Debug($"Reloading rule files: {string.Join(", ", ruleFiles)}");
 
+			// TODO: exception handling: file access error, syntax error, etc.
 			var yamlNodes = MiniYaml.LoadWithoutInherits(modData.DefaultFileSystem, ruleFiles, null);
 			static bool FilterNode(MiniYamlNode node) => node.Key.StartsWith(ActorInfo.AbstractActorPrefix);
 			var unresolvedRules = LoadFilteredYamlToDictionary(modData.DefaultFileSystem, yamlNodes, "UnresolvedRulesYaml", FilterNode);
@@ -232,7 +235,6 @@ namespace OpenRA
 			}
 
 			CallRulesetLoadedOnActorsList(actorInfos);
-			world.RecreateActors();
 			//world.Actors.Where(a => actorInfos.Select(i => i.Name).Contains(a.Info.Name))
 			//	.ToList().ForEach(a => a.LoadCachedTraits());
 		}

--- a/OpenRA.Game/GameRules/Ruleset.cs
+++ b/OpenRA.Game/GameRules/Ruleset.cs
@@ -273,9 +273,11 @@ namespace OpenRA
 		{
 			if (weaponFiles == null || weaponFiles.Length == 0)
 			{
-				Console.WriteLine("No weapon file specified, reloading all weapon files.");
+				TextNotificationsManager.Debug("No weapon file specified, reloading all weapon files.");
 				weaponFiles = modData.Manifest.Weapons;
 			}
+			else
+				TextNotificationsManager.Debug($"Reloading weapon files: {string.Join(", ", weaponFiles)}");
 
 			var yamlNodes = MiniYaml.LoadWithoutInherits(modData.DefaultFileSystem, weaponFiles, null);
 			var unresolvedWeapons = LoadFilteredYamlToDictionary(modData.DefaultFileSystem, yamlNodes, "UnresolvedWeaponsYaml");

--- a/OpenRA.Game/GameRules/RulesetWatcher.cs
+++ b/OpenRA.Game/GameRules/RulesetWatcher.cs
@@ -151,6 +151,8 @@ namespace OpenRA.GameRules
 			if (sequenceFiles.Length > 0)
 				TryExecute(() => world.Map.Sequences.ReloadSequenceSetFromFiles(modData.DefaultFileSystem, sequenceFiles));
 
+			if (Game.Settings.Debug.RecreateActorsAfterRulesetReload)
+				world.RecreateActors();
 
 			static IEnumerable<string> FindModFiles(IEnumerable<string> allFiles, ISet<string> findFiles)
 				=> allFiles.Where(findFiles.Contains);

--- a/OpenRA.Game/GameRules/RulesetWatcher.cs
+++ b/OpenRA.Game/GameRules/RulesetWatcher.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenRA.GameRules
+{
+	public sealed class RulesetWatcher : IDisposable
+	{
+		static readonly StringComparer FileNameComparer = Platform.CurrentPlatform == PlatformType.Windows
+			? StringComparer.OrdinalIgnoreCase
+			: StringComparer.Ordinal;
+
+		static readonly TimeSpan DebounceInterval = TimeSpan.FromMilliseconds(100);
+
+		readonly object syncLock = new();
+
+		readonly World world;
+		readonly ModData modData;
+		readonly IReadOnlyDictionary<string, string> watchFiles;
+		readonly HashSet<string> fileQueue = new(FileNameComparer);
+		readonly FileSystemWatcher watcher;
+
+		volatile bool isEnabled;
+		bool isDisposed;
+
+		CancellationTokenSource debounceCts;
+
+		public bool IsEnabled => isEnabled;
+
+		public RulesetWatcher(World world, ModData modData)
+		{
+			this.world = world;
+			this.modData = modData;
+
+			var dict = new Dictionary<string, string>(FileNameComparer);
+			foreach (var file in modData.Manifest.Rules
+				.Concat(modData.Manifest.Weapons)
+				.Concat(modData.Manifest.Sequences))
+			{
+				string filename;
+				using (var stream = modData.DefaultFileSystem.Open(file))
+					filename = (stream as FileStream)?.Name;
+
+				if (string.IsNullOrEmpty(filename))
+					continue;
+
+				var fullPath = Path.GetFullPath(filename);
+				dict.Add(fullPath, file);
+			}
+
+			watchFiles = dict.ToImmutableDictionary(FileNameComparer);
+
+			watcher = new FileSystemWatcher(modData.Manifest.Package.Name)
+			{
+				IncludeSubdirectories = true
+			};
+			watcher.Changed += FileChanged;
+
+			foreach (var file in watchFiles.Keys)
+			{
+				watcher.Filters.Add(Path.GetFileName(file));
+			}
+		}
+
+		public void ToggleWatching(bool toggleValue)
+		{
+			if (isDisposed)
+				throw new ObjectDisposedException(nameof(RulesetWatcher));
+
+			lock (syncLock)
+			{
+				if (isDisposed)
+					throw new ObjectDisposedException(nameof(RulesetWatcher));
+
+				watcher.EnableRaisingEvents = toggleValue;
+
+				isEnabled = toggleValue;
+
+				if (!toggleValue)
+				{
+					debounceCts?.Dispose();
+					fileQueue.Clear();
+				}
+			}
+		}
+
+		void FileChanged(object sender, FileSystemEventArgs e)
+		{
+			if (!watchFiles.ContainsKey(e.FullPath))
+				return;
+
+			lock (syncLock)
+			{
+				if (!isEnabled || isDisposed)
+					return;
+
+				fileQueue.Add(e.FullPath);
+
+				if (debounceCts != null)
+				{
+					debounceCts.Cancel();
+					debounceCts.Dispose();
+				}
+
+				// Since CancellationTokenSource is already thread-safe, let's leverage that for a debounce mechanism:
+				// Taking a local copy of CancellationToken from current CancellationTokenSource makes sure that current Task can be cancelled
+				// by the next thread. Also, we cannot store CancellationTokenSource, since after it is disposed, CancellationToken cannot be accessed anymore.
+				// Superfluous CancellationTokenSource will be disposed in ToggleWatching() or Dispose().
+				debounceCts = new CancellationTokenSource();
+				var localToken = debounceCts.Token;
+
+				Task.Run(async () =>
+				{
+					await Task.Delay(DebounceInterval, localToken);
+
+					List<string> changedFiles;
+					lock (syncLock)
+					{
+						changedFiles = fileQueue.ToList();
+						fileQueue.Clear();
+					}
+
+					Game.RunAfterTick(() => DoRulesetReload(changedFiles));
+				});
+			}
+		}
+
+		void DoRulesetReload(ICollection<string> files)
+		{
+			lock (syncLock)
+			{
+				if (isDisposed || !isEnabled || files.Count == 0)
+					return;
+			}
+
+			var modFsFilenames = files.Select(f => watchFiles[f]).ToHashSet(FileNameComparer);
+
+			var defaultRules = world.Map.Rules;
+			var rulesFiles = FindModFiles(modData.Manifest.Rules, modFsFilenames).ToArray();
+			var weaponFiles = FindModFiles(modData.Manifest.Weapons, modFsFilenames).ToArray();
+			var sequenceFiles = FindModFiles(modData.Manifest.Sequences, modFsFilenames).ToArray();
+
+			if (rulesFiles.Length > 0)
+				TryExecute(() => defaultRules.LoadActorTraitsFromRuleFile(world, modData, rulesFiles));
+			if (weaponFiles.Length > 0)
+				TryExecute(() => defaultRules.LoadWeaponsFromFile(world, modData, weaponFiles));
+			if (sequenceFiles.Length > 0)
+				TryExecute(() => world.Map.Sequences.ReloadSequenceSetFromFiles(modData.DefaultFileSystem, sequenceFiles));
+
+
+			static IEnumerable<string> FindModFiles(IEnumerable<string> allFiles, ISet<string> findFiles)
+				=> allFiles.Where(findFiles.Contains);
+
+			static void TryExecute(Action action, int attempts = 2)
+			{
+				for (var i = 0; i < attempts; i++)
+				{
+					try
+					{
+						action();
+
+						return;
+					}
+					catch (IOException)
+					{
+						// IO errors are not critical, we should be able to retry them a few times (and even swallow them, if they keep occurring)
+						// TODO: error handling should be in each respective code that reloads ruleset/sequences/etc.
+					}
+				}
+			}
+		}
+
+		public void Dispose()
+		{
+			if (isDisposed)
+				return;
+
+			lock (syncLock)
+			{
+				if (isDisposed)
+					return;
+
+				debounceCts?.Dispose();
+				fileQueue.Clear();
+
+				isEnabled = false;
+				isDisposed = true;
+
+				watcher.Changed -= FileChanged;
+				watcher.Dispose();
+			}
+		}
+	}
+}

--- a/OpenRA.Game/Graphics/SequenceSet.cs
+++ b/OpenRA.Game/Graphics/SequenceSet.cs
@@ -135,7 +135,15 @@ namespace OpenRA.Graphics
 		public void ReloadSequenceSetFromFiles(IReadOnlyFileSystem fileSystem, string[] sequencesFiles = null, MiniYaml newAddSequences = null)
 		{
 			Dictionary<string, Dictionary<string, ISpriteSequence>> newImages;
-			sequencesFiles ??= modData.Manifest.Sequences;
+
+			if (sequencesFiles == null || sequencesFiles.Length == 0)
+			{
+				TextNotificationsManager.Debug("No sequence file specified, reloading all sequence files.");
+				sequencesFiles = modData.Manifest.Sequences;
+			}
+			else
+				TextNotificationsManager.Debug($"Reloading sequence files: {string.Join(", ", sequencesFiles)}");
+
 			newAddSequences ??= additionalSequences;
 			newImages = Load(fileSystem, sequencesFiles, newAddSequences);
 			images = newImages;

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -181,6 +181,9 @@ namespace OpenRA
 
 		[Desc("Enable automatic ruleset when changed externally.")]
 		public bool EnableRulesetAutoReload = false;
+
+		[Desc("Recreate actors after ruleset is reloaded.")]
+		public bool RecreateActorsAfterRulesetReload = true;
 	}
 
 	public class GraphicSettings

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -178,6 +178,9 @@ namespace OpenRA
 
 		[Desc("Throw an exception if the world sync hash changes while evaluating BotModules.")]
 		public bool SyncCheckBotModuleCode = false;
+
+		[Desc("Enable automatic ruleset when changed externally.")]
+		public bool EnableRulesetAutoReload = false;
 	}
 
 	public class GraphicSettings

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -13,19 +13,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Numerics;
-using System.Reflection;
-using OpenRA.Activities;
 using OpenRA.Effects;
 using OpenRA.FileFormats;
-using OpenRA.FileSystem;
 using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Orders;
 using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Traits;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace OpenRA
 {
@@ -86,7 +81,7 @@ namespace OpenRA
 				foreach (var t in WorldActor.TraitsImplementing<IGameOver>())
 					t.GameOver(this);
 
-				GameInfo.FinalGameTick = WorldTick;
+				gameInfo.FinalGameTick = WorldTick;
 				GameOver();
 			}
 		}
@@ -149,7 +144,7 @@ namespace OpenRA
 		public readonly IValidateOrder[] OrderValidators;
 		readonly INotifyPlayerDisconnected[] notifyDisconnected;
 
-		public readonly GameInformation GameInfo;
+		readonly GameInformation gameInfo;
 
 		// Hide the OrderManager from mod code
 		public void IssueOrder(Order o) { OrderManager.IssueOrder(o); }
@@ -236,7 +231,7 @@ namespace OpenRA
 
 			Game.Sound.SoundVolumeModifier = 1.0f;
 
-			GameInfo = new GameInformation
+			gameInfo = new GameInformation
 			{
 				Mod = Game.ModData.Manifest.Id,
 				Version = Game.ModData.Manifest.Metadata.Version,
@@ -302,14 +297,14 @@ namespace OpenRA
 						iwl.WorldLoaded(this, wr);
 
 			foreach (var player in Players)
-				GameInfo.AddPlayer(player, OrderManager.LobbyInfo);
+				gameInfo.AddPlayer(player, OrderManager.LobbyInfo);
 
-			GameInfo.DisabledSpawnPoints = OrderManager.LobbyInfo.DisabledSpawnPoints;
+			gameInfo.DisabledSpawnPoints = OrderManager.LobbyInfo.DisabledSpawnPoints;
 
-			GameInfo.StartTimeUtc = DateTime.UtcNow;
+			gameInfo.StartTimeUtc = DateTime.UtcNow;
 
 			if (OrderManager.Connection is NetworkConnection nc && nc.Recorder != null)
-				nc.Recorder.Metadata = new ReplayMetadata(GameInfo);
+				nc.Recorder.Metadata = new ReplayMetadata(gameInfo);
 		}
 
 		public void PostLoadComplete(WorldRenderer wr)
@@ -553,7 +548,7 @@ namespace OpenRA
 
 		public void OnPlayerWinStateChanged(Player player)
 		{
-			var pi = GameInfo.GetPlayer(player);
+			var pi = gameInfo.GetPlayer(player);
 			if (pi != null)
 			{
 				pi.Outcome = player.WinState;
@@ -571,7 +566,7 @@ namespace OpenRA
 				foreach (var p in Players)
 					p.PlayerDisconnected(player);
 
-				var pi = GameInfo.GetPlayer(player);
+				var pi = gameInfo.GetPlayer(player);
 				if (pi != null)
 					pi.DisconnectFrame = OrderManager.NetFrameNumber;
 			}

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -86,7 +86,7 @@ namespace OpenRA
 				foreach (var t in WorldActor.TraitsImplementing<IGameOver>())
 					t.GameOver(this);
 
-				gameInfo.FinalGameTick = WorldTick;
+				GameInfo.FinalGameTick = WorldTick;
 				GameOver();
 			}
 		}
@@ -149,7 +149,7 @@ namespace OpenRA
 		public readonly IValidateOrder[] OrderValidators;
 		readonly INotifyPlayerDisconnected[] notifyDisconnected;
 
-		readonly GameInformation gameInfo;
+		public readonly GameInformation GameInfo;
 
 		// Hide the OrderManager from mod code
 		public void IssueOrder(Order o) { OrderManager.IssueOrder(o); }
@@ -236,7 +236,7 @@ namespace OpenRA
 
 			Game.Sound.SoundVolumeModifier = 1.0f;
 
-			gameInfo = new GameInformation
+			GameInfo = new GameInformation
 			{
 				Mod = Game.ModData.Manifest.Id,
 				Version = Game.ModData.Manifest.Metadata.Version,
@@ -302,14 +302,14 @@ namespace OpenRA
 						iwl.WorldLoaded(this, wr);
 
 			foreach (var player in Players)
-				gameInfo.AddPlayer(player, OrderManager.LobbyInfo);
+				GameInfo.AddPlayer(player, OrderManager.LobbyInfo);
 
-			gameInfo.DisabledSpawnPoints = OrderManager.LobbyInfo.DisabledSpawnPoints;
+			GameInfo.DisabledSpawnPoints = OrderManager.LobbyInfo.DisabledSpawnPoints;
 
-			gameInfo.StartTimeUtc = DateTime.UtcNow;
+			GameInfo.StartTimeUtc = DateTime.UtcNow;
 
 			if (OrderManager.Connection is NetworkConnection nc && nc.Recorder != null)
-				nc.Recorder.Metadata = new ReplayMetadata(gameInfo);
+				nc.Recorder.Metadata = new ReplayMetadata(GameInfo);
 		}
 
 		public void PostLoadComplete(WorldRenderer wr)
@@ -553,7 +553,7 @@ namespace OpenRA
 
 		public void OnPlayerWinStateChanged(Player player)
 		{
-			var pi = gameInfo.GetPlayer(player);
+			var pi = GameInfo.GetPlayer(player);
 			if (pi != null)
 			{
 				pi.Outcome = player.WinState;
@@ -571,7 +571,7 @@ namespace OpenRA
 				foreach (var p in Players)
 					p.PlayerDisconnected(player);
 
-				var pi = gameInfo.GetPlayer(player);
+				var pi = GameInfo.GetPlayer(player);
 				if (pi != null)
 					pi.DisconnectFrame = OrderManager.NetFrameNumber;
 			}

--- a/OpenRA.Mods.Common/Traits/World/RuntimeRulesetReload.cs
+++ b/OpenRA.Mods.Common/Traits/World/RuntimeRulesetReload.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Commands;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[TraitLocation(SystemActors.World)]
+	[Desc("Handles ruleset reloading at runtime.")]
+	public class RuntimeRulesetReloadInfo : TraitInfo
+	{
+		public override object Create(ActorInitializer init)
+		{
+			return new RuntimeRulesetReload();
+		}
+	}
+
+	public class RuntimeRulesetReload : IChatCommand, IWorldLoaded, IPostWorldLoaded
+	{
+		[TranslationReference]
+		const string CheatsDisabled = "notification-cheats-disabled";
+
+		[TranslationReference]
+		const string CommandDescription = "description-ruleset-autoreload";
+
+		const string CommandName = "autoreload";
+
+		[TranslationReference]
+		const string AutoReloadEnabled = "notification-ruleset-autoreload-enabled";
+
+		[TranslationReference]
+		const string AutoReloadDisabled = "notification-ruleset-autoreload-disabled";
+
+		[TranslationReference]
+		const string CommandArgumentError = "notification-ruleset-autoreload-invalid-argument";
+
+		[TranslationReference]
+		const string AutoReloadMultiplayerDisabled = "notification-ruleset-autoreload-multiplayer-disabled";
+
+		World world;
+		DeveloperMode developerMode;
+
+		public bool Enabled
+		{
+			get => Game.Settings.Debug.EnableRulesetAutoReload;
+			set => Game.Settings.Debug.EnableRulesetAutoReload = value;
+		}
+
+		void IWorldLoaded.WorldLoaded(World w, WorldRenderer wr)
+		{
+			world = w;
+
+			if (world.LocalPlayer != null)
+				developerMode = world.LocalPlayer.PlayerActor.Trait<DeveloperMode>();
+
+			var console = w.WorldActor.TraitOrDefault<ChatCommands>();
+			var help = w.WorldActor.TraitOrDefault<HelpCommand>();
+
+			if (console == null || help == null)
+				return;
+
+			console.RegisterCommand(CommandName, this);
+			help.RegisterHelp(CommandName, CommandDescription);
+		}
+
+		void IPostWorldLoaded.PostWorldLoaded(World w, WorldRenderer wr)
+		{
+			if (Enabled && w.GameInfo.IsSinglePlayer)
+				Game.RulesetWatcher.ToggleWatching(true);
+		}
+
+		void IChatCommand.InvokeCommand(string name, string arg)
+		{
+			if (world.LocalPlayer == null)
+				return;
+
+			if (!developerMode.Enabled)
+			{
+				TextNotificationsManager.Debug(TranslationProvider.GetString(CheatsDisabled));
+				return;
+			}
+
+			if (!world.GameInfo.IsSinglePlayer)
+			{
+				TextNotificationsManager.Debug(TranslationProvider.GetString(AutoReloadMultiplayerDisabled));
+				return;
+			}
+
+			if (name == CommandName)
+			{
+				bool shouldEnable;
+				if (string.IsNullOrEmpty(arg))
+					shouldEnable = !Enabled;
+				else if (!TryParseOnOffBoolean(arg.Trim(), out shouldEnable))
+				{
+					TextNotificationsManager.Debug(TranslationProvider.GetString(CommandArgumentError));
+					return;
+				}
+
+				Enabled = shouldEnable;
+
+				TextNotificationsManager.Debug(TranslationProvider.GetString(shouldEnable ? AutoReloadEnabled : AutoReloadDisabled));
+			}
+
+			static bool TryParseOnOffBoolean(string value, out bool result)
+			{
+				result = false;
+
+				value = value.ToLowerInvariant();
+				if ("on".Equals(value, StringComparison.OrdinalIgnoreCase))
+				{
+					result = true;
+					return true;
+				}
+				else if ("off".Equals(value, StringComparison.OrdinalIgnoreCase))
+				{
+					result = true;
+					return true;
+				}
+
+				return false;
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/AdvancedSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/AdvancedSettingsLogic.cs
@@ -96,12 +96,5 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ds.RecreateActorsAfterRulesetReload = dds.RecreateActorsAfterRulesetReload;
 			};
 		}
-
-		protected override void Dispose(bool disposing)
-		{
-			base.Dispose(disposing);
-
-			Game.RulesetWatcher?.ToggleWatching(Game.Settings.Debug.EnableRulesetAutoReload);
-		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/AdvancedSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/AdvancedSettingsLogic.cs
@@ -55,6 +55,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SettingsUtils.BindCheckboxPref(panel, "CHECKUNSYNCED_CHECKBOX", ds, "SyncCheckUnsyncedCode");
 			SettingsUtils.BindCheckboxPref(panel, "CHECKBOTSYNC_CHECKBOX", ds, "SyncCheckBotModuleCode");
 			SettingsUtils.BindCheckboxPref(panel, "PERFLOGGING_CHECKBOX", ds, "EnableSimulationPerfLogging");
+			SettingsUtils.BindCheckboxPref(panel, "RULESET_AUTORELOAD_CHECKBOX", ds, "EnableRulesetAutoReload");
 
 			panel.Get("BOTDEBUG_CHECKBOX_CONTAINER").IsVisible = () => ds.DisplayDeveloperSettings;
 			panel.Get("CHECKUNSYNCED_CHECKBOX_CONTAINER").IsVisible = () => ds.DisplayDeveloperSettings;
@@ -63,6 +64,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			panel.Get("REPLAY_COMMANDS_CHECKBOX_CONTAINER").IsVisible = () => ds.DisplayDeveloperSettings;
 			panel.Get("PERFLOGGING_CHECKBOX_CONTAINER").IsVisible = () => ds.DisplayDeveloperSettings;
 			panel.Get("DEBUG_HIDDEN_CONTAINER").IsVisible = () => !ds.DisplayDeveloperSettings;
+			panel.Get("RULESET_AUTORELOAD_CONTAINER").IsVisible = () => ds.DisplayDeveloperSettings;
 
 			SettingsUtils.AdjustSettingsScrollPanelLayout(scrollPanel);
 
@@ -89,6 +91,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ds.CheckVersion = dds.CheckVersion;
 				ds.EnableDebugCommandsInReplays = dds.EnableDebugCommandsInReplays;
 				ds.EnableSimulationPerfLogging = dds.EnableSimulationPerfLogging;
+				ds.EnableRulesetAutoReload = dds.EnableRulesetAutoReload;
 			};
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/AdvancedSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/AdvancedSettingsLogic.cs
@@ -56,6 +56,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SettingsUtils.BindCheckboxPref(panel, "CHECKBOTSYNC_CHECKBOX", ds, "SyncCheckBotModuleCode");
 			SettingsUtils.BindCheckboxPref(panel, "PERFLOGGING_CHECKBOX", ds, "EnableSimulationPerfLogging");
 			SettingsUtils.BindCheckboxPref(panel, "RULESET_AUTORELOAD_CHECKBOX", ds, "EnableRulesetAutoReload");
+			SettingsUtils.BindCheckboxPref(panel, "RULESET_AUTORELOAD_RECREATE_ACTORS_CHECKBOX", ds, "RecreateActorsAfterRulesetReload");
 
 			panel.Get("BOTDEBUG_CHECKBOX_CONTAINER").IsVisible = () => ds.DisplayDeveloperSettings;
 			panel.Get("CHECKUNSYNCED_CHECKBOX_CONTAINER").IsVisible = () => ds.DisplayDeveloperSettings;
@@ -92,7 +93,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ds.EnableDebugCommandsInReplays = dds.EnableDebugCommandsInReplays;
 				ds.EnableSimulationPerfLogging = dds.EnableSimulationPerfLogging;
 				ds.EnableRulesetAutoReload = dds.EnableRulesetAutoReload;
+				ds.RecreateActorsAfterRulesetReload = dds.RecreateActorsAfterRulesetReload;
 			};
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			base.Dispose(disposing);
+
+			Game.RulesetWatcher?.ToggleWatching(Game.Settings.Debug.EnableRulesetAutoReload);
 		}
 	}
 }

--- a/mods/cnc/chrome/settings-advanced.yaml
+++ b/mods/cnc/chrome/settings-advanced.yaml
@@ -195,4 +195,17 @@ Container@ADVANCED_PANEL:
 									Height: 20
 									Font: Regular
 									Text: checkbox-perflogging-container
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 20
+					Children:
+						Container@RULESET_AUTORELOAD_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@RULESET_AUTORELOAD_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: checkbox-ruleset-autoreload
 

--- a/mods/cnc/chrome/settings-advanced.yaml
+++ b/mods/cnc/chrome/settings-advanced.yaml
@@ -208,4 +208,13 @@ Container@ADVANCED_PANEL:
 									Height: 20
 									Font: Regular
 									Text: checkbox-ruleset-autoreload
+						Container@RULESET_AUTORELOAD_RECREATE_ACTORS_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@RULESET_AUTORELOAD_RECREATE_ACTORS_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: checkbox-ruleset-autoreload-recreate-actors
 

--- a/mods/common/chrome/settings-advanced.yaml
+++ b/mods/common/chrome/settings-advanced.yaml
@@ -195,4 +195,17 @@ Container@ADVANCED_PANEL:
 									Height: 20
 									Font: Regular
 									Text: checkbox-perflogging-container
+				Container@ROW:
+					Width: PARENT_RIGHT - 24
+					Height: 20
+					Children:
+						Container@RULESET_AUTORELOAD_CONTAINER:
+							X: 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@RULESET_AUTORELOAD_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: checkbox-ruleset-autoreload
 

--- a/mods/common/chrome/settings-advanced.yaml
+++ b/mods/common/chrome/settings-advanced.yaml
@@ -208,4 +208,13 @@ Container@ADVANCED_PANEL:
 									Height: 20
 									Font: Regular
 									Text: checkbox-ruleset-autoreload
+						Container@RULESET_AUTORELOAD_RECREATE_ACTORS_CONTAINER:
+							X: PARENT_RIGHT / 2 + 10
+							Width: PARENT_RIGHT / 2 - 20
+							Children:
+								Checkbox@RULESET_AUTORELOAD_RECREATE_ACTORS_CHECKBOX:
+									Width: PARENT_RIGHT
+									Height: 20
+									Font: Regular
+									Text: checkbox-ruleset-autoreload-recreate-actors
 

--- a/mods/common/languages/chrome/en.ftl
+++ b/mods/common/languages/chrome/en.ftl
@@ -457,6 +457,7 @@ checkbox-checkunsynced-container = Check Sync around Unsynced Code
 checkbox-replay-commands-container = Enable Debug Commands in Replays
 checkbox-perflogging-container = Enable Tick Performance Logging
 checkbox-ruleset-autoreload = Enable Ruleset Auto Reload
+checkbox-ruleset-autoreload-recreate-actors = Recreate Actors After Ruleset Is Reloaded
 
 ## settings-audio.yaml
 label-audio-section-header = Audio

--- a/mods/common/languages/chrome/en.ftl
+++ b/mods/common/languages/chrome/en.ftl
@@ -456,6 +456,7 @@ checkbox-luadebug-container = Show Map Debug Messages
 checkbox-checkunsynced-container = Check Sync around Unsynced Code
 checkbox-replay-commands-container = Enable Debug Commands in Replays
 checkbox-perflogging-container = Enable Tick Performance Logging
+checkbox-ruleset-autoreload = Enable Ruleset Auto Reload
 
 ## settings-audio.yaml
 label-audio-section-header = Audio

--- a/mods/common/languages/en.ftl
+++ b/mods/common/languages/en.ftl
@@ -781,6 +781,13 @@ description-path-debug-overlay = toggles a visualization of path searching.
 ## TerrainGeometryOverlay
 description-terrain-geometry-overlay = toggles the terrain geometry overlay.
 
+## RuntimeRulesetReload
+description-ruleset-autoreload = enables/disables automatic reload of ruleset when changed externally.
+notification-ruleset-autoreload-multiplayer-disabled = Automatic reload of ruleset cannot be enabled in multiplayer.
+notification-ruleset-autoreload-enabled = Automatic reload of ruleset enabled.
+notification-ruleset-autoreload-disabled = Automatic reload of ruleset disabled.
+notification-ruleset-autoreload-invalid-argument = Invalid argument value. Valid values: <no argument>, true, false
+
 ## MapOptions, MissionBrowserLogic
 options-game-speed =
     .slowest = Slowest

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -168,6 +168,7 @@ World:
 	DebugVisualizationCommands:
 	PathFinderOverlay:
 	HierarchicalPathFinderOverlay:
+	RuntimeRulesetReload:
 	PlayerCommands:
 	HelpCommand:
 	ScreenShaker:


### PR DESCRIPTION
`RulesetWatcher`:
- main feature of the PR
- auto reloads actor, weapon and sequence YAML files when any of them changes
- has rudimentary retry mechanism for transient IO errors (like file access or not found errors)

`/autoreload` chat command:
- no argument -> toggles autoreload
- argument `on` or `off` -> enables or disables autoreload
- cannot be used in multiplayer game (a game with more than 1 human player)
- autoreload is controlled via `EnableRulesetAutoReload` in `DebugSettings`

Advanced settings:
- checkbox `Enable Ruleset Auto Reload` enables or disables pref `EnableRulesetAutoReload` in `settings.yaml`
- checkbox `Recreate Actors After Ruleset Is Reloaded` enables or disables automatic recreation of actors after ruleset reload in `Ruleset.LoadActorTraitsFromRuleFile()`

Other changes:
- made `World.gameInfo` public

![image](https://github.com/user-attachments/assets/a2b20dd0-9c06-4713-a23f-13caf1440bbf)

![image](https://github.com/user-attachments/assets/1cdb2277-3bfa-41d1-b2c6-3e6d64024265)
